### PR TITLE
Fixes for readr 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,3 +38,5 @@ License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr
 RoxygenNote: 5.0.1
+Remotes:
+    tidyverse/readr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,5 +38,3 @@ License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr
 RoxygenNote: 5.0.1
-Remotes:
-    tidyverse/readr

--- a/tests/testthat/test-pnpp_experiment-filled.R
+++ b/tests/testthat/test-pnpp_experiment-filled.R
@@ -20,5 +20,5 @@ test_that("get_filled_drops works", {
                    get_filled_drops(plate, "A05", border_A05))
   
   expect_equal(get_filled_drops(plate, "A05"),
-                   readr::read_csv(file.path(dir, "A05_filled.csv")))
+                   readr::read_csv(file.path(dir, "A05_filled.csv"), col_types = "ii"))
 })

--- a/tests/testthat/test-v174.R
+++ b/tests/testthat/test-v174.R
@@ -3,7 +3,7 @@ context("v174")
 test_that("reading v174 works", {
   dir <- system.file("sample_data", "read_v174", package = "ddpcr")
   plate <- new_plate(dir) 
-  expected_data <- readr::read_csv(file.path(dir, "expected_data.csv"))
+  expected_data <- readr::read_csv(file.path(dir, "expected_data.csv"), col_types = "ciii")
   expect_equal(expected_data, plate_data(plate))
   
   meta <- plate %>% plate_meta(only_used = TRUE)


### PR DESCRIPTION
readr 1.2.0 no longer guesses columns are of type integer, rather these
columns are always guessed as type double.

This breaking change caused two errors in your ddpcr package, fixed by
the changes in this commit.

Sorry for the breakage!